### PR TITLE
Fix typo on 'Electron' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://www.androidpolice.com/2020/05/27/google-chats-desktop-application-is-now
 * [electrino](https://github.com/pojala/electrino)
 * [graffiti](https://github.com/cztomsik/graffiti)
 * [Tauri](https://github.com/tauri-apps/tauri)
-* [Sciter.JS](https://github.com/c-smile/sciter-js-sdk) (Is a 5MB HTML/CSS/JS (ES6) runtime aimed as a direct Electorn replacement)
+* [Sciter.JS](https://github.com/c-smile/sciter-js-sdk) (Is a 5MB HTML/CSS/JS (ES6) runtime aimed as a direct Electron replacement)
 
 # Dart
 * [flutter](https://flutter.dev)


### PR DESCRIPTION
Just a small typo fix